### PR TITLE
gitignoreの修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# containers以降をpushしない
+containers/


### PR DESCRIPTION
containers以降の不要なデータがpushされてしまっていたため
`containers/`とすることでcontainers以降はpushしないように