### PR TITLE
ステップ10: Railsのタイムゾーンを設定

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,5 +29,8 @@ module App
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local
   end
 end


### PR DESCRIPTION
## やったこと
タイムゾーンを東京に変更

Application.rbで
```
config.time_zone = ENV["TZ"]
config.time_zone = 'Tokyo'
    config.active_record.default_timezone = :local

```
とすることでUTFから東京に

## やらないこと

## できるようになること（ユーザ目線）
正確な時間を確認できる

## できなくなること（ユーザ目線）
東京の時刻のため海外の時刻ではない

## 動作確認
Rails consoleにて
Time.zone.name 
→"Tokyo"
Time.current
→現在の日時
