### PR TITLE
ステップ9: アプリの日本語部分を共通化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,3 +63,5 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,6 +133,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (5.1.3)
+      i18n (>= 0.7, < 2)
+      railties (>= 5.0, < 6)
     railties (5.2.4.5)
       actionpack (= 5.2.4.5)
       activesupport (= 5.2.4.5)
@@ -245,6 +248,7 @@ DEPENDENCIES
   pg (~> 1.1.4)
   puma (~> 3.11)
   rails (~> 5.2.3)
+  rails-i18n
   rspec-rails
   rubocop
   rubocop-performance

--- a/app/assets/stylesheets/tasks.scss
+++ b/app/assets/stylesheets/tasks.scss
@@ -42,3 +42,9 @@ p{
     transform: translateY(4px);
     border-bottom: none;
 }
+
+.alert {
+    color:#262626; 
+    background:#FFEBE8;
+    text-align: center;
+}

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,4 +1,13 @@
 <h1>タスクの作成</h1>
+<% if @task.errors.any? %>
+  <div class = "alert">
+    <ul>
+      <% @task.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end%>
 <% @task=Task.new unless @task %>
 <%= form_for(@task) do |f| %>
     <%= f.label :name, 'タスク' %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,5 +34,8 @@ module App
 
     config.time_zone = 'Tokyo'
     config.active_record.default_timezone = :local
+
+    config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.yml').to_s]
   end
 end

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -1,0 +1,7 @@
+ja:
+  activerecord:
+    attributes:
+      task:
+        name: 名前
+        detail: 詳細
+        


### PR DESCRIPTION
## やったこと
バリデーションエラーを日本語に
gemfileにi18nを追加しapplication.rbに
    `config.i18n.default_locale = :ja`を追加し日本語に
しかしこのままではカラム名は英語のままなためconfig/models/ja.ymlを作成し
そこにカラム名を日本語にするコードを記述しapplication.rbにて
`config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.yml').to_s]
`
とすることでパスを通しカラム名も日本語に

## やらないこと

## できるようになること（ユーザ目線）
エラーが出たとき日本語で見れる

## できなくなること（ユーザ目線）
エラーが出たときの表記が英語では無い

## 動作確認
実際にエラーが出る様にnameを空にしてタスクを作成したところ
**名前を入力してください**
というバリデーションエラーが出力
