### PR TITLE
ステップ11: タスク一覧を作成日時の順番で並び替えよう

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -4,7 +4,7 @@ class TasksController < ApplicationController
   # 全てのタスクを取得する
   # @return [Array<Task>]
   def index
-    @tasks = Task.all
+    @tasks = Task.all.order(created_at: :desc)
   end
 
   # 対象タスクを取得する

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe TasksController, type: :request do
   describe '#index' do
     subject { get tasks_path }
 
-    let!(:task1) { create(:task, created_at:Time.current) }
-    let!(:task2) { create(:task, created_at:Time.current + 1.hour) }
-    let!(:task3) { create(:task, created_at:Time.current + 2.hours) }
+    let!(:task1) { create(:task, created_at: Time.current) }
+    let!(:task2) { create(:task, created_at: Time.current + 1.hour) }
+    let!(:task3) { create(:task, created_at: Time.current + 2.hours) }
 
     it 'リクエストが成功すること' do
       subject
@@ -16,9 +16,9 @@ RSpec.describe TasksController, type: :request do
       expect(response).to have_http_status(200)
     end
 
-    it "並び順が正しいこと" do
+    it '並び順が正しいこと' do
       subject
-      expect(controller.instance_variable_get('@tasks')).to eq ([task3,task2,task1])
+      expect(controller.instance_variable_get('@tasks')).to eq([task3, task2, task1])
     end
   end
 

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -6,10 +6,19 @@ RSpec.describe TasksController, type: :request do
   describe '#index' do
     subject { get tasks_path }
 
+    let!(:task1) { create(:task, created_at:Time.current) }
+    let!(:task2) { create(:task, created_at:Time.current + 1.hour) }
+    let!(:task3) { create(:task, created_at:Time.current + 2.hours) }
+
     it 'リクエストが成功すること' do
       subject
       expect(response).to be_success
       expect(response).to have_http_status(200)
+    end
+
+    it "並び順が正しいこと" do
+      subject
+      expect(controller.instance_variable_get('@tasks')).to eq ([task3,task2,task1])
     end
   end
 


### PR DESCRIPTION
## やったこと
indexアクションにて`@tasks = Task.all.order(created_at: :desc)`をすることで作成日時順に並び替え。

またそれらのテストをspec/controllers/tasks_controller_spec.rbのindexアクションの部分に追加

## やらないこと

## できるようになること（ユーザ目線）
作成日時順にタスクを見れる

## できなくなること（ユーザ目線）

## 動作確認
rootページを再度読みこみ並び替えが成功しているかを確認。

テストにて
```
let!(:task1) { create(:task, created_at: Time.current) }
let!(:task2) { create(:task, created_at: Time.current + 1.hour) }
let!(:task3) { create(:task, created_at: Time.current + 2.hours) 

```
これら３つのテストデータを作成し、task3,task2,task1の順番になっているかを確認。
