### PR TITLE
ステップ16: 終了期限を追加

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -4,7 +4,8 @@ class TasksController < ApplicationController
   # 全てのタスクを取得する
   # @return [Array<Task>]
   def index
-    @tasks = Task.all.order(created_at: :desc)
+    @deadline_sort = params[:deadline_date_sort]
+    @tasks = Task.deadline_sort(@deadline_sort)
   end
 
   # 対象タスクを取得する
@@ -67,6 +68,6 @@ class TasksController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:name, :detail)
+    params.require(:task).permit(:name, :detail, :deadline_date)
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -4,8 +4,11 @@ class TasksController < ApplicationController
   # 全てのタスクを取得する
   # @return [Array<Task>]
   def index
-    @deadline_sort = params[:deadline_date_sort]
-    @tasks = Task.deadline_sort(@deadline_sort)
+    if params[:deadline_date_sort_type].present?
+      @tasks = Task.all.order(deadline_date: params[:deadline_date_sort_type])
+    else
+      @tasks = Task.all.order(created_at: :desc)
+    end
   end
 
   # 対象タスクを取得する

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,4 +2,19 @@
 
 class Task < ApplicationRecord
   validates :name, presence: true
+
+  # 引数の値がnil,true,falseによって一覧をソート
+  # @param [String] params[:deadline_date_sort]
+  # return [] 引数がnilの場合created_atを降順
+  # return [] 引数のdeadline_date_sortがtrueの場合、deadline＿dateを昇順
+  # return [] 引数のdeadline_date_sortがfalseの場合、deadline＿dateを降順
+  def self.deadline_sort(sort)
+    if sort.nil?
+      order(created_at: :desc)
+    elsif ActiveRecord::Type::Boolean.new.cast(sort)
+      order(deadline_date: :asc)
+    else
+      order(deadline_date: :desc)
+    end
+  end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,19 +2,4 @@
 
 class Task < ApplicationRecord
   validates :name, presence: true
-
-  # 引数の値がnil,true,falseによって一覧をソート
-  # @param [String] params[:deadline_date_sort]
-  # return [] 引数がnilの場合created_atを降順
-  # return [] 引数のdeadline_date_sortがtrueの場合、deadline＿dateを昇順
-  # return [] 引数のdeadline_date_sortがfalseの場合、deadline＿dateを降順
-  def self.deadline_sort(sort)
-    if sort.nil?
-      order(created_at: :desc)
-    elsif ActiveRecord::Type::Boolean.new.cast(sort)
-      order(deadline_date: :asc)
-    else
-      order(deadline_date: :desc)
-    end
-  end
 end

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -5,6 +5,8 @@
     <%= f.text_field :name %>
     <%= f.label :detail, '詳細' %>
     <%= f.text_area :detail %>
+    <%= f.label :deadline_date, '終了期限' %>
+    <%= f.date_select :deadline_date %>
     <%= f.submit '編集' %>
 <% end %>
 

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,5 +1,5 @@
-<%= link_to "締め切りに近い順", tasks_path(deadline_date_sort: true)%>
-<%= link_to "締め切りに遠い順", tasks_path(deadline_date_sort: false)%>
+<%= link_to "締め切りに近い順", tasks_path(deadline_date_sort_type: "asc")%>
+<%= link_to "締め切りに遠い順", tasks_path(deadline_date_sort_type: "desc")%>
 <h1>一覧</h1>
 <hr>
 <ul>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,3 +1,5 @@
+<%= link_to "締め切りに近い順", tasks_path(deadline_date_sort: true)%>
+<%= link_to "締め切りに遠い順", tasks_path(deadline_date_sort: false)%>
 <h1>一覧</h1>
 <hr>
 <ul>
@@ -15,4 +17,3 @@
 <div class = "back">
   <%= link_to "作成", new_task_path, {class: "back_button"} %>
 </div>
-

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -14,6 +14,8 @@
     <%= f.text_field :name %>
     <%= f.label :detail, '詳細' %>
     <%= f.text_area :detail %>
+    <%= f.label :deadline_date, '終了期限' %>
+    <%= f.date_select :deadline_date %>
     <%= f.submit '作成' %>
 <% end %>
 

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,6 +1,7 @@
 <h1><%= @task.name %></h1>
 <hr>
 <p><%= @task.detail %></p>
+<p><%= @task.deadline_date %></p>
 
 <div class = "back">
     <%= link_to "一覧へ",tasks_path,{class:"back_button"}%>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -60,6 +60,4 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
-
-  config.hosts << ".herokuapp.com"
 end

--- a/db/migrate/20210217131503_add_deadline_at_to_tasks.rb
+++ b/db/migrate/20210217131503_add_deadline_at_to_tasks.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDeadlineAtToTasks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tasks, :deadline_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_210_215_054_736) do
+ActiveRecord::Schema.define(version: 20_210_217_131_503) do
   # These are extensions that must be enabled in order to support this database
   enable_extension 'plpgsql'
 
@@ -21,5 +21,6 @@ ActiveRecord::Schema.define(version: 20_210_215_054_736) do
     t.text 'detail'
     t.datetime 'created_at', null: false
     t.datetime 'updated_at', null: false
+    t.date 'deadline_date'
   end
 end

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -37,6 +37,11 @@ RSpec.describe TasksController, type: :request do
         subject
         expect(response.body).to include 'task'
       end
+
+      it '終了期限が表示されていること' do
+        subject
+        expect(response.body).to include '2021-02-18'
+      end
     end
 
     context 'タスクが存在しない時' do

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe TasksController, type: :request do
   describe '#index' do
     subject { get tasks_path }
 
-    let!(:task1) { create(:task, created_at: Time.current) }
-    let!(:task2) { create(:task, created_at: Time.current + 1.hour) }
-    let!(:task3) { create(:task, created_at: Time.current + 2.hours) }
+    let!(:task1) { create(:task, created_at: Time.current, deadline_date: Date.current + 3.days) }
+    let!(:task2) { create(:task, created_at: Time.current + 1.hour, deadline_date: Date.current + 10.days) }
+    let!(:task3) { create(:task, created_at: Time.current + 2.hours, deadline_date: Date.current + 7.days) }
 
     it 'リクエストが成功すること' do
       subject
@@ -19,6 +19,16 @@ RSpec.describe TasksController, type: :request do
     it '並び順が正しいこと' do
       subject
       expect(controller.instance_variable_get('@tasks')).to eq([task3, task2, task1])
+    end
+
+    it '締め切り日に近い順にソートが行われていること' do
+      get tasks_path, params: {deadline_date_sort_type: "asc"}
+      expect(controller.instance_variable_get('@tasks')).to eq([task1, task3, task2])
+    end
+
+    it '締め切り日に遠い順にソートが行われていること' do
+      get tasks_path, params: {deadline_date_sort_type: "desc"}
+      expect(controller.instance_variable_get('@tasks')).to eq([task2, task3, task1])
     end
   end
 

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
   factory :task do
     name { 'name' }
     detail { 'detail' }
+    deadline_date { '2021-02-18' }
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Task, type: :model do
     it 'nameが空白である場合エラーが表示されること' do
       task = build(:task, name: nil)
       task.valid?
-      expect(task.errors[:name]).to include("can't be blank")
+      expect(task.errors[:name]).to include('を入力してください')
     end
   end
 end


### PR DESCRIPTION
## やったこと
1.終了期限の追加
deadline_dateカラムを追加し終了期限のデータを作成。
new,editテンプレートにname,detail同様終了期限作成フォームを追加。
showテンプレートでは`@task.deadline_date`をすることで追加した終了期限を表示。

2.終了期限のソート
indexテンプレートに**締め切りに近い順**、**締め切りに遠い順**のリンクを作成し**締め切りに近い順**を押すことで`deadline_date_sort_type`を"asc"に、**締め切りに遠い順**を押すと`deadline_date_sort_type`を"desc"にすることでソートを実現。
ロジックはtasks_controller.rbにて`deadline_date_sort_type`がない場合は作成日順で表示しある場合viewから送られてきた`deadline_date_sort_type`の値が**asc**か**desc**かでソート

3.spec
spec/factries/task.rbのテストデータにdealline_dateを追加しsupec/controllers/tasks_controller_spec.rbのshowアクション部分に終了期限が表示されているかのテストを追加

## やらないこと

## できるようになること（ユーザ目線）
終了期限が早い、遅いでソートできる様になる

## できなくなること（ユーザ目線）


## 動作確認
一覧画面で締め切りに近い順、遠い順のリンクを押して正しくソートできているかを確認

`docker-compose run --rm -e RAILS_ENV=test app bundle exec rspec spec/controllers/tasks_controller_spec.rb`
→**20 examples, 0 failures**

`docker-compose run --rm app bundle exec rubocop`
→**47 files inspected, no offenses detected**

## その他
models/task.rbの終了期限のソートのロジック部分のコメントの件でreturnでorderメソッドを返しているのですがそちらのデータ型が分からずデータ型の部分は空白にしてしまった。