### PR TITLE
ステップ17: ステータスを追加して、検索できるようにしよう

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -5,13 +5,10 @@ class TasksController < ApplicationController
   # @return [Array<Task>]
   # @return [Array<Status>]
   def index
-    @statuses = Status.all
     @tasks = Task.all.order(created_at: :desc)
-    @tasks = Task.search_status_id(params[:status_id]) if params[:status_id].present?
-    @tasks = Task.search_task_name(params[:name]) if params[:name].present?
-    if params[:deadline_date_sort_type].present?
-      @tasks = Task.all.order(deadline_date: params[:deadline_date_sort_type])
-    end
+    @tasks = Task.where(status_id: params[:status_id]) if params[:status_id].present?
+    @tasks = Task.where('name LIKE ?',"%#{params[:name]}%" ) if params[:name].present?
+    @tasks = Task.all.order(deadline_date: params[:deadline_date_sort_type]) if params[:deadline_date_sort_type].present?
   end
 
   # 対象タスクを取得する

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -3,20 +3,15 @@
 class TasksController < ApplicationController
   # 全てのタスクを取得する
   # @return [Array<Task>]
+  # @return [Array<Status>]
   def index
     @statuses = Status.all
-    tasks_name = params[:name]
-    status_id = params[:status_id]
-    if tasks_name.present? && status_id.present? 
-      @tasks = Task.search_status_id(status_id).search_task_name(tasks_name)
-    elsif status_id.present?
-      @tasks = Task.search_status_id(status_id)
-    elsif params[:deadline_date_sort_type].present?
+    @tasks = Task.all.order(created_at: :desc)
+    @tasks = Task.search_status_id(params[:status_id]) if params[:status_id].present?
+    @tasks = Task.search_task_name(params[:name]) if params[:name].present?
+    if params[:deadline_date_sort_type].present?
       @tasks = Task.all.order(deadline_date: params[:deadline_date_sort_type])
-    else
-      @tasks = Task.all.order(created_at: :desc)
     end
-    
   end
 
   # 対象タスクを取得する
@@ -28,8 +23,6 @@ class TasksController < ApplicationController
   # タスクインスタンスを作成
   def new
     @task = Task.new
-    @statuses = Status.all
-    @task.build_status
   end
 
   # タスクを作成
@@ -37,7 +30,6 @@ class TasksController < ApplicationController
   # return [nil] saveされなかった時new.html.erbにレンダリング
   def create
     @task = Task.new(task_params)
-    @task.status_id = params[:task][:status_id].to_i
     if @task.save
       flash[:succcess] = 'タスクが作成されました'
       redirect_to @task
@@ -81,6 +73,6 @@ class TasksController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:name, :detail, :deadline_date, :status_id )
+    params.require(:task).permit(:name, :detail, :deadline_date, :status_id)
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -3,7 +3,6 @@
 class TasksController < ApplicationController
   # 全てのタスクを取得する
   # @return [Array<Task>]
-  # @return [Array<Status>]
   def index
     @tasks = Task.all.order(created_at: :desc)
     @tasks = Task.where(status_id: params[:status_id]) if params[:status_id].present?

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -4,19 +4,19 @@ class TasksController < ApplicationController
   # 全てのタスクを取得する
   # @return [Array<Task>]
   def index
-    if params[:deadline_date_sort_type].present?
+    @statuses = Status.all
+    tasks_name = params[:name]
+    status_id = params[:status_id]
+    if tasks_name.present? && status_id.present? 
+      @tasks = Task.search_status_id(status_id).search_task_name(tasks_name)
+    elsif status_id.present?
+      @tasks = Task.search_status_id(status_id)
+    elsif params[:deadline_date_sort_type].present?
       @tasks = Task.all.order(deadline_date: params[:deadline_date_sort_type])
     else
       @tasks = Task.all.order(created_at: :desc)
     end
-
-    # Statusモデルのnameカラムの検索（statusのnameの取得が分からない)
-    if params[:status].present?
-      @tasks = Task.where("ここが知りたい。 LIKE ?","#{params[:status]}")
-    # Taskモデルのnameカラムの検索
-    elsif params[:name].present?
-      @tasks = Task.where("name LIKE ?","%#{params[:name]}%")
-    end
+    
   end
 
   # 対象タスクを取得する
@@ -36,7 +36,6 @@ class TasksController < ApplicationController
   # return [nil] saveされなかった時new.html.erbにレンダリング
   def create
     @task = Task.new(task_params)
-
     if @task.save
       flash[:succcess] = 'タスクが作成されました'
       redirect_to @task
@@ -80,6 +79,6 @@ class TasksController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:name, :detail, :deadline_date, status_attributes: [:name])
+    params.require(:task).permit(:name, :detail, :deadline_date, status_attributes: [:name] )
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -28,6 +28,7 @@ class TasksController < ApplicationController
   # タスクインスタンスを作成
   def new
     @task = Task.new
+    @statuses = Status.all
     @task.build_status
   end
 
@@ -36,6 +37,7 @@ class TasksController < ApplicationController
   # return [nil] saveされなかった時new.html.erbにレンダリング
   def create
     @task = Task.new(task_params)
+    @task.status_id = params[:task][:status_id].to_i
     if @task.save
       flash[:succcess] = 'タスクが作成されました'
       redirect_to @task
@@ -79,6 +81,6 @@ class TasksController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:name, :detail, :deadline_date, status_attributes: [:name] )
+    params.require(:task).permit(:name, :detail, :deadline_date, :status_id )
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -9,6 +9,14 @@ class TasksController < ApplicationController
     else
       @tasks = Task.all.order(created_at: :desc)
     end
+
+    # Statusモデルのnameカラムの検索（statusのnameの取得が分からない)
+    if params[:status].present?
+      @tasks = Task.where("ここが知りたい。 LIKE ?","#{params[:status]}")
+    # Taskモデルのnameカラムの検索
+    elsif params[:name].present?
+      @tasks = Task.where("name LIKE ?","%#{params[:name]}%")
+    end
   end
 
   # 対象タスクを取得する
@@ -20,6 +28,7 @@ class TasksController < ApplicationController
   # タスクインスタンスを作成
   def new
     @task = Task.new
+    @task.build_status
   end
 
   # タスクを作成
@@ -71,6 +80,6 @@ class TasksController < ApplicationController
   private
 
   def task_params
-    params.require(:task).permit(:name, :detail, :deadline_date)
+    params.require(:task).permit(:name, :detail, :deadline_date, status_attributes: [:name])
   end
 end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Status < ApplicationRecord
+  has_many :tasks
+end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 class Status < ApplicationRecord
+  validates :name, presence: true
   has_many :tasks
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -4,4 +4,7 @@ class Task < ApplicationRecord
   belongs_to :status
   accepts_nested_attributes_for :status
   validates :name, presence: true
+
+  scope :search_status_id, ->(status_id) { where('cast(status_id as text) LIKE ?', "#{status_id}") }
+  scope :search_task_name, ->(task_name) { where('name LIKE ?', "#{task_name}")}
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,9 +2,9 @@
 
 class Task < ApplicationRecord
   belongs_to :status
-  accepts_nested_attributes_for :status
+  # accepts_nested_attributes_for :status
   validates :name, presence: true
 
-  scope :search_status_id, ->(status_id) { where('cast(status_id as text) LIKE ?', "#{status_id}") }
-  scope :search_task_name, ->(task_name) { where('name LIKE ?', "#{task_name}")}
+  scope :search_status_id, ->(status_id) { where('cast(status_id as text) LIKE ?', status_id.to_s) }
+  scope :search_task_name, ->(task_name) { where('name LIKE ?', task_name.to_s) }
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,9 +2,5 @@
 
 class Task < ApplicationRecord
   belongs_to :status
-  # accepts_nested_attributes_for :status
   validates :name, presence: true
-
-  scope :search_status_id, ->(status_id) { where('cast(status_id as text) LIKE ?', status_id.to_s) }
-  scope :search_task_name, ->(task_name) { where('name LIKE ?', task_name.to_s) }
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 class Task < ApplicationRecord
+  belongs_to :status
+  accepts_nested_attributes_for :status
   validates :name, presence: true
 end

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -7,9 +7,7 @@
     <%= f.text_area :detail %>
     <%= f.label :deadline_date, '終了期限' %>
     <%= f.date_select :deadline_date %>
-    <%= f.fields_for :status do |s|%>
-      <%= s.select :name, [["未着手", "未着手"], ["着手", "着手"], ["完了", "完了"]], include_blank: "選択して下さい" %>
-    <% end %>
+    <%= f.collection_select(:status_id,Status.all, :id, :name )%> 
     <%= f.submit '編集' %>
 <% end %>
 

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -7,6 +7,9 @@
     <%= f.text_area :detail %>
     <%= f.label :deadline_date, '終了期限' %>
     <%= f.date_select :deadline_date %>
+    <%= f.fields_for :status do |s|%>
+      <%= s.select :name, [["未着手", "未着手"], ["着手", "着手"], ["完了", "完了"]], include_blank: "選択して下さい" %>
+    <% end %>
     <%= f.submit '編集' %>
 <% end %>
 

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,17 +1,13 @@
 <%= link_to "締め切りに近い順", tasks_path(deadline_date_sort_type: "asc")%>
 <%= link_to "締め切りに遠い順", tasks_path(deadline_date_sort_type: "desc")%>
 
-<%= form_with url: tasks_path, local: true, method: :get do |form| %>
-  <%= form.label :name, 'タスク名' %> 
-  <%= form.text_field :name %>
-  <%= form.submit '検索' %>
+<%= form_with url:tasks_path, method: :get, local: true do |f| %>
+  <%= f.label :name, 'Sarch status' %> 
+    <%= f.text_field :name %>
+    <%= f.collection_select(:status_id,@statuses, :id, :name )%>
+  <%= f.submit '検索' %> 
 <% end %>
 
-<%= form_with url:tasks_path, method: :get, local: true do |form| %>
-  <%= form.label :status, 'ステータス' %> 
-    <%= form.select :status, [["未着手", "未着手"], ["着手", "着手"], ["完了", "完了"]], include_blank: "選択して下さい" %>
-  <%= form.submit '検索' %> 
-<% end %>
 <h1>一覧</h1>
 <hr>
 <ul>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -5,7 +5,7 @@
   <%= f.label :name, '名前' %> 
   <%= f.text_field :name %>
   <%= f.label :status_id, 'ステータス' %> 
-  <%= f.collection_select(:status_id,@statuses, :id, :name )%>
+  <%= f.collection_select(:status_id,Status.all, :id, :name )%>
   <%= f.submit '検索' %> 
 <% end %>
 

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -2,9 +2,10 @@
 <%= link_to "締め切りに遠い順", tasks_path(deadline_date_sort_type: "desc")%>
 
 <%= form_with url:tasks_path, method: :get, local: true do |f| %>
-  <%= f.label :name, 'Sarch status' %> 
-    <%= f.text_field :name %>
-    <%= f.collection_select(:status_id,@statuses, :id, :name )%>
+  <%= f.label :name, '名前' %> 
+  <%= f.text_field :name %>
+  <%= f.label :status_id, 'ステータス' %> 
+  <%= f.collection_select(:status_id,@statuses, :id, :name )%>
   <%= f.submit '検索' %> 
 <% end %>
 

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,5 +1,17 @@
 <%= link_to "締め切りに近い順", tasks_path(deadline_date_sort_type: "asc")%>
 <%= link_to "締め切りに遠い順", tasks_path(deadline_date_sort_type: "desc")%>
+
+<%= form_with url: tasks_path, local: true, method: :get do |form| %>
+  <%= form.label :name, 'タスク名' %> 
+  <%= form.text_field :name %>
+  <%= form.submit '検索' %>
+<% end %>
+
+<%= form_with url:tasks_path, method: :get, local: true do |form| %>
+  <%= form.label :status, 'ステータス' %> 
+    <%= form.select :status, [["未着手", "未着手"], ["着手", "着手"], ["完了", "完了"]], include_blank: "選択して下さい" %>
+  <%= form.submit '検索' %> 
+<% end %>
 <h1>一覧</h1>
 <hr>
 <ul>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -8,22 +8,17 @@
     </ul>
   </div>
 <% end%>
-<% @task=Task.new unless @task %>
-<%= form_for(@task) do |f| %>
-    <%= f.label :name, 'タスク' %>
-    <%= f.text_field :name %>
-    <%= f.label :detail, '詳細' %>
-    <%= f.text_area :detail %>
-    <%= f.label :deadline_date, '終了期限' %>
-    <%= f.date_select :deadline_date %>
-    <%= f.fields_for :status do |s|%>
-      <%= s.select :name, [["未着手", "未着手"], ["着手", "着手"], ["完了", "完了"]], include_blank: "選択して下さい" %>
-    <% end %>
-    <%= f.submit '作成' %>
+<%= form_with model:@task ,url: tasks_path, method: :post, local: true do |f|%>
+  <%= f.label :name, 'タスク' %>
+  <%= f.text_field :name %>
+  <%= f.label :detail, '詳細' %>
+  <%= f.text_area :detail %>
+  <%= f.label :deadline_date, '終了期限' %>
+  <%= f.date_select :deadline_date %>
+  <%= f.label :status_id, 'ステータス' %>
+  <%= f.collection_select(:status_id,@statuses, :id, :name )%>
+  <%= f.submit %>
 <% end %>
-
-
-
 
 <div class = "back">
     <%= link_to "一覧へ",tasks_path,{class:"back_button"}%>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -16,6 +16,9 @@
     <%= f.text_area :detail %>
     <%= f.label :deadline_date, '終了期限' %>
     <%= f.date_select :deadline_date %>
+    <%= f.fields_for :status do |s|%>
+      <%= s.select :name, [["未着手", "未着手"], ["着手", "着手"], ["完了", "完了"]], include_blank: "選択して下さい" %>
+    <% end %>
     <%= f.submit '作成' %>
 <% end %>
 

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -16,7 +16,7 @@
   <%= f.label :deadline_date, '終了期限' %>
   <%= f.date_select :deadline_date %>
   <%= f.label :status_id, 'ステータス' %>
-  <%= f.collection_select(:status_id,@statuses, :id, :name )%>
+  <%= f.collection_select(:status_id,Status.all, :id, :name )%>
   <%= f.submit %>
 <% end %>
 

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -22,6 +22,9 @@
     <%= f.submit '作成' %>
 <% end %>
 
+
+
+
 <div class = "back">
     <%= link_to "一覧へ",tasks_path,{class:"back_button"}%>
 </div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -2,6 +2,10 @@
 <hr>
 <p><%= @task.detail %></p>
 <p><%= @task.deadline_date %></p>
+<% if @task.status.name.present? %>
+    <p><%= @task.status.name %></p>
+<% end %>
+
 
 <div class = "back">
     <%= link_to "一覧へ",tasks_path,{class:"back_button"}%>

--- a/db/migrate/20210222012748_create_statuses.rb
+++ b/db/migrate/20210222012748_create_statuses.rb
@@ -1,0 +1,9 @@
+class CreateStatuses < ActiveRecord::Migration[5.2]
+  def change
+    create_table :statuses do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210222012748_create_statuses.rb
+++ b/db/migrate/20210222012748_create_statuses.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateStatuses < ActiveRecord::Migration[5.2]
   def change
     create_table :statuses do |t|

--- a/db/migrate/20210222014732_add_status_id_to_tasks.rb
+++ b/db/migrate/20210222014732_add_status_id_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddStatusIdToTasks < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :tasks, :status, foreign_key: true
+  end
+end

--- a/db/migrate/20210222014732_add_status_id_to_tasks.rb
+++ b/db/migrate/20210222014732_add_status_id_to_tasks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddStatusIdToTasks < ActiveRecord::Migration[5.2]
   def change
     add_reference :tasks, :status, foreign_key: true

--- a/db/migrate/20210301124303_change_columns_add_notnull_on_statuses.rb
+++ b/db/migrate/20210301124303_change_columns_add_notnull_on_statuses.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeColumnsAddNotnullOnStatuses < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :statuses, :name, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -10,26 +12,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_22_014732) do
-
+ActiveRecord::Schema.define(version: 20_210_301_124_303) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension 'plpgsql'
 
-  create_table "statuses", force: :cascade do |t|
-    t.string "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table 'statuses', force: :cascade do |t|
+    t.string 'name', null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
   end
 
-  create_table "tasks", force: :cascade do |t|
-    t.string "name", null: false
-    t.text "detail"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.date "deadline_date"
-    t.bigint "status_id"
-    t.index ["status_id"], name: "index_tasks_on_status_id"
+  create_table 'tasks', force: :cascade do |t|
+    t.string 'name', null: false
+    t.text 'detail'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.date 'deadline_date'
+    t.bigint 'status_id'
+    t.index ['status_id'], name: 'index_tasks_on_status_id'
   end
 
-  add_foreign_key "tasks", "statuses"
+  add_foreign_key 'tasks', 'statuses'
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,15 +10,26 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_210_217_131_503) do
-  # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+ActiveRecord::Schema.define(version: 2021_02_22_014732) do
 
-  create_table 'tasks', force: :cascade do |t|
-    t.string 'name', null: false
-    t.text 'detail'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.date 'deadline_date'
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "statuses", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
+
+  create_table "tasks", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "detail"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.date "deadline_date"
+    t.bigint "status_id"
+    t.index ["status_id"], name: "index_tasks_on_status_id"
+  end
+
+  add_foreign_key "tasks", "statuses"
 end

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -96,11 +96,13 @@ RSpec.describe TasksController, type: :request do
 
       it 'タスクが登録される' do
         expect do
+          FactoryBot.create(:status)
           subject
         end.to change(Task, :count).by(1)
       end
 
       it 'リダイレクトされること' do
+        FactoryBot.create(:status)
         subject
         expect(response.status).to eq 302
         expect(response).to redirect_to Task.last

--- a/spec/factories/statuses.rb
+++ b/spec/factories/statuses.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-    factory :status do
-      name { '着手' }
-    end
+  factory :status do
+    name { '着手' }
+  end
 end

--- a/spec/factories/statuses.rb
+++ b/spec/factories/statuses.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+    factory :status do
+      name { '着手' }
+    end
+end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -5,10 +5,6 @@ FactoryBot.define do
     name { 'name' }
     detail { 'detail' }
     deadline_date { '2021-02-18' }
-    association :status, factory: :status
-  end
-
-  factory :status, class: Status do
-    name {"着手"}
+    association :status
   end
 end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -5,5 +5,10 @@ FactoryBot.define do
     name { 'name' }
     detail { 'detail' }
     deadline_date { '2021-02-18' }
+    association :status, factory: :status
+  end
+
+  factory :status, class: Status do
+    name {"着手"}
   end
 end

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Status, type: :model do
+  context 'パラメータが正常な場合' do
+    it 'インスタンスが確保されること' do
+      status = build(:status)
+      expect(status).to be_valid
+    end
+  end
+
+  context 'パラメータが不正な場合' do
+    it 'nameが空白である場合エラーが表示されること' do
+      status = build(:status, name: nil)
+      status.valid?
+      expect(status.errors[:name]).to include('を入力してください')
+    end
+  end
+end


### PR DESCRIPTION
## やったこと
・statusesテーブルの作成(nameのみ),notnull制約

`add_reference :tasks, :status, foreign_key: true
`
とすることでtasksテーブルに外部キーであるstatus_idを作成。

・タスク名、ステータス名の検索
```
scope :search_status_id, ->(status_id) { where('cast(status_id as text) LIKE ?', status_id.to_s) }
scope :search_task_name, ->(task_name) { where('name LIKE ?', task_name.to_s) }
```
それぞれmodels/task.rbにスコープとして処理を記述。
tasks_controllerでif文でparamにstatus_idまたはnameがあるかで`＠tasks`に検索結果を代入
ステータスの値は予めマスターデータとしてnameに"未着手","着手","完了"を登録。
## やらないこと


## できるようになること（ユーザ目線）
タスク名で検索できる。
ステータスが未着手、着手、完了であるかを検索できる。

## できなくなること（ユーザ目線）


## 動作確認
index.html.erbの部分で実際に検索し確認。
specにタスク名の検索、ステータスの検索のテストを記述し確認。

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）