### PR TITLE
ユーザにロールを追加しよう

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,4 +1,6 @@
 class Admin::UsersController < ApplicationController
+  before_action :admin_user
+
   # 全てのユーザーを取得
   # @return [Array<User>]
   def index
@@ -59,13 +61,17 @@ class Admin::UsersController < ApplicationController
   def destroy
     @user = User.find(params[:id])
     @user.destroy
-    flash[:success] = 'ユーザーが削除されました'
+    flash.now[:success] = 'ユーザーが削除されました'
     redirect_to admin_users_path
   end
 
   private
 
   def user_params
-    params.require(:user).permit(:name, :email, :password, :password_confirmation)
+    params.require(:user).permit(:name, :email, :password, :password_confirmation, :is_admin)
+  end
+
+  def admin_user
+    redirect_to(root_path) unless current_user.is_admin?
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -64,7 +64,7 @@ class Admin::UsersController < ApplicationController
       flash.now[:success] = 'ユーザーが削除されました'
       redirect_to admin_users_path
     else
-      flash[:danger] = '管理者は最低1人必要です'
+      render :show
     end
   end
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -60,9 +60,12 @@ class Admin::UsersController < ApplicationController
   # @return [User]
   def destroy
     @user = User.find(params[:id])
-    @user.destroy
-    flash.now[:success] = 'ユーザーが削除されました'
-    redirect_to admin_users_path
+    if @user.destroy
+      flash.now[:success] = 'ユーザーが削除されました'
+      redirect_to admin_users_path
+    else
+      flash[:danger] = '管理者は最低1人必要です'
+    end
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,6 @@ class User < ApplicationRecord
 
   def leave_at_least_one_admin_user
     unless User.where(is_admin: true).count > 1
-      errors.add(:is_admin, "管理者は最低1人必要です")
       throw(:abort)
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,13 @@ class User < ApplicationRecord
   has_many :tasks, dependent: :destroy
   validates :name, presence: true
   has_secure_password
+
+  before_destroy :leave_at_least_one_admin_user
+
+  def leave_at_least_one_admin_user
+    unless User.where(is_admin: true).count > 1
+      errors.add(:is_admin, "管理者は最低1人必要です")
+      throw(:abort)
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
 
   def leave_at_least_one_admin_user
     unless User.where(is_admin: true).count > 1
-      errors.add(:is_admin, "は最低1人必要です")
+      errors.add(:is_admin, 'は最低1人必要です')
       throw(:abort)
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,7 @@ class User < ApplicationRecord
 
   def leave_at_least_one_admin_user
     unless User.where(is_admin: true).count > 1
+      errors.add(:is_admin, "は最低1人必要です")
       throw(:abort)
     end
   end

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -17,6 +17,10 @@
     <%= f.password_field :password_confirmation,class: "form-control" %>
   </div>
   <div class="form-group">
+    <%= f.label :is_admin, '権限' %>
+    <%= f.select :is_admin, {'管理者ユーザー': true, 'ユーザー': false}, { include_blank: '選択してください'} %>
+  </div>
+  <div class="form-group">
     <%= f.submit "編集", class: 'btn btn-success' %>
   </div>
 <% end %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -14,13 +14,6 @@
     </thead>
     <tbody>
       <% @users.each do |user| %>
-        <% if user.errors.any? %>
-            <ul>
-                <% user.errors.full_messages.each do |message| %>
-                     <li><%= message %></li>
-                <% end %>
-            </ul>
-        <% end %>
         <% if @users %>
           <tr>
             <td><%= link_to user.name, admin_user_path(user) %></td>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,6 +1,6 @@
 <div class="mx-auto" style="width: 200px;">
-    <h1>一覧</h1>
-  </div>
+  <h1>一覧</h1>
+</div>
   <h2><%= link_to 'ユーザーを作成', new_admin_user_path ,class: 'btn btn-info'%></h2>
   <table class="table">
     <thead>
@@ -9,16 +9,29 @@
         <td>タスク数</td>
         <td>編集</td>
         <td>削除</td>
+        <td>管理者権限</td>
       </tr>
     </thead>
     <tbody>
       <% @users.each do |user| %>
+        <% if user.errors.any? %>
+            <ul>
+                <% user.errors.full_messages.each do |message| %>
+                     <li><%= message %></li>
+                <% end %>
+            </ul>
+        <% end %>
         <% if @users %>
           <tr>
             <td><%= link_to user.name, admin_user_path(user) %></td>
             <td><%= user.tasks_count %></td>
             <td><%= link_to "編集", edit_admin_user_path(user),class: 'btn btn-success' %></td>
             <td><%= link_to '削除する', admin_user_path(user), method: :delete, data:{ confirm: '本当に削除してよろしいですか？'}, class: "btn btn-danger" %></td>
+            <%if user.is_admin%>
+                <td>あり</td>
+            <% else%>
+                <td>なし</td>
+            <% end %>
           </tr>
         <% else %>
           <tr>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -24,11 +24,12 @@
                 <td><%= link_to "編集", edit_task_path(task),class: 'btn btn-success' %></td>
                 <td><%= link_to '削除する', task, method: :delete, data:{ confirm: '本当に削除してよろしいですか？'}, class: "btn btn-danger" %></td>
             </tr>
-            <tr>
-                <td>タスクがありません</td>
-            </tr>
         <% end %>
         <%= paginate @tasks %>
+      <% else %>
+        <tr>
+          <td>タスクがありません</td>
+        </tr>
       <% end %>
     </tbody>
 </table>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,3 +1,10 @@
+<% if @user.errors.any? %>
+    <ul>
+        <% @user.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+        <% end %>
+    </ul>
+<% end %>
 <h1><%= @user.name %></h1>
 <hr>
 <p><%= @user.email %></p>
@@ -10,23 +17,25 @@
       </tr>
     </thead>
     <tbody>
-      <% @tasks.each do |task| %>
-        <% if @tasks %>
-          <tr>
-            <td><%= link_to task.name, task %></td>
-            <td><%= link_to "編集", edit_task_path(task),class: 'btn btn-success' %></td>
-            <td><%= link_to '削除する', task, method: :delete, data:{ confirm: '本当に削除してよろしいですか？'}, class: "btn btn-danger" %></td>
-          </tr>
-        <% else %>
-          <tr>
-            <td>タスクがありません</td>
-          </tr>
+      <% if @tasks %>
+        <% @tasks.each do |task| %>
+            <% if @tasks %>
+            <tr>
+                <td><%= link_to task.name, task %></td>
+                <td><%= link_to "編集", edit_task_path(task),class: 'btn btn-success' %></td>
+                <td><%= link_to '削除する', task, method: :delete, data:{ confirm: '本当に削除してよろしいですか？'}, class: "btn btn-danger" %></td>
+            </tr>
+            <% else %>
+            <tr>
+                <td>タスクがありません</td>
+            </tr>
+            <% end %>
         <% end %>
       <% end %>
     </tbody>
 </table>
 
-<%= paginate @tasks %>
+<%= paginate @tasks if @tasks %>
 <hr>
 
 <%= link_to "一覧へ",admin_users_path,class: 'btn btn-primary'%>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -19,23 +19,20 @@
     <tbody>
       <% if @tasks %>
         <% @tasks.each do |task| %>
-            <% if @tasks %>
             <tr>
                 <td><%= link_to task.name, task %></td>
                 <td><%= link_to "編集", edit_task_path(task),class: 'btn btn-success' %></td>
                 <td><%= link_to '削除する', task, method: :delete, data:{ confirm: '本当に削除してよろしいですか？'}, class: "btn btn-danger" %></td>
             </tr>
-            <% else %>
             <tr>
                 <td>タスクがありません</td>
             </tr>
-            <% end %>
         <% end %>
+        <%= paginate @tasks %>
       <% end %>
     </tbody>
 </table>
 
-<%= paginate @tasks if @tasks %>
 <hr>
 
 <%= link_to "一覧へ",admin_users_path,class: 'btn btn-primary'%>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,4 +1,5 @@
   <%= link_to "ログアウト", logout_path, method: :delete %>
+  <%= link_to "管理者画面", admin_users_path %>
   <%= form_with url:tasks_path, method: :get, local: true do |f| %>
     <%= f.label :name, '名前' %> 
     <%= f.text_field :name %>

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -4,4 +4,10 @@ ja:
       task:
         name: 名前
         detail: 詳細
+        deadline_date: 終了期限
+      user:
+        name: ユーザー名
+        email: メールアドレス
+        password_digest: パスワード
+        is_admin: 管理者
         

--- a/db/migrate/20210324135524_add_column_to_user.rb
+++ b/db/migrate/20210324135524_add_column_to_user.rb
@@ -1,0 +1,5 @@
+class AddColumnToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :admin, :boolean, default: false
+  end
+end

--- a/db/migrate/20210325041300_rename_admin_column_to_users.rb
+++ b/db/migrate/20210325041300_rename_admin_column_to_users.rb
@@ -1,0 +1,5 @@
+class RenameAdminColumnToUsers < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :users, :admin, :is_admin
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_210_323_083_905) do
+ActiveRecord::Schema.define(version: 20_210_325_041_300) do
   # These are extensions that must be enabled in order to support this database
   enable_extension 'plpgsql'
 
@@ -47,6 +47,7 @@ ActiveRecord::Schema.define(version: 20_210_323_083_905) do
     t.datetime 'updated_at', null: false
     t.string 'password_digest'
     t.integer 'tasks_count', default: 0, null: false
+    t.boolean 'is_admin', default: false
   end
 
   add_foreign_key 'tasks', 'priorities'

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,5 +6,13 @@ FactoryBot.define do
     email { 'test@test.com' }
     password { 'password' }
     password_confirmation { 'password' }
+    is_admin { false }
+  end
+  trait :admin do
+    name { 'admin' }
+    email { 'admin@admin.com' }
+    password { 'admin' }
+    password_confirmation { 'admin' }
+    is_admin { true }
   end
 end

--- a/spec/requests/admin/users_request_spec.rb
+++ b/spec/requests/admin/users_request_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe 'Admin::Users', type: :request do
         end.to change { User.find(admin.id).email }.from('admin@admin.com').to('admin2@admin.com')
       end
 
-      it 'メールアドレスが更新されること' do
+      it '管理者権限が更新されること' do
         expect do
           subject
         end.to change { User.find(admin.id).is_admin }.from(true).to(false)

--- a/spec/requests/admin/users_request_spec.rb
+++ b/spec/requests/admin/users_request_spec.rb
@@ -1,4 +1,229 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe 'Admin::Users', type: :request do
+  let!(:admin) { create(:user, :admin) }
+  before do
+    post login_path,
+         params: { session: FactoryBot.attributes_for(:user, :admin, email: admin.email, password: admin.password,
+                                                                     is_admin: admin.is_admin) }
+  end
+
+  describe '#index' do
+    context '管理者でログインしている場合' do
+      subject { get admin_users_path }
+
+      it 'リクエストが成功すること' do
+        subject
+        expect(response).to be_success
+        expect(response).to have_http_status(200)
+      end
+    end
+    context '一般ユーザーでログインしている場合' do
+      let(:user) { create(:user) }
+      before do
+        post login_path,
+             params: { session: FactoryBot.attributes_for(:user, email: user.email, password: user.password,
+                                                                 is_admin: user.is_admin) }
+      end
+      subject { get admin_users_path }
+
+      it 'ルートパスにリダイレクトされること' do
+        subject
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
+  describe '#show' do
+    context 'ユーザーが存在している場合' do
+      subject { get admin_user_path admin.id }
+
+      it 'リクエストが成功すること' do
+        subject
+        expect(response).to be_success
+        expect(response).to have_http_status(200)
+      end
+
+      it 'ユーザー名が表示されていること' do
+        subject
+        expect(response.body).to include 'admin'
+      end
+
+      it 'メールアドレスが表示されていること' do
+        subject
+        expect(response.body).to include 'admin@admin.com'
+      end
+    end
+
+    context 'ユーザーが存在しない場合' do
+      subject { -> { get admin_user_path 5 } }
+
+      it { is_expected.to raise_error ActiveRecord::RecordNotFound }
+    end
+  end
+
+  describe '#new' do
+    subject { get new_admin_user_path }
+
+    it 'リクエストが成功すること' do
+      subject
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  describe '#edit' do
+    subject { get edit_admin_user_path admin }
+
+    it 'リクエストが成功すること' do
+      subject
+      expect(response).to have_http_status(200)
+    end
+
+    it 'ユーザー名が表示されていること' do
+      subject
+      expect(response.body).to include 'admin'
+    end
+
+    it 'メールアドレスが表示されていること' do
+      subject
+      expect(response.body).to include 'admin@admin.com'
+    end
+  end
+
+  describe '#create' do
+    context 'パラメータが妥当な場合' do
+      subject do
+        post admin_users_path, params: { user: FactoryBot.attributes_for(:user, :admin) }
+      end
+
+      it 'ユーザーが登録されること' do
+        expect do
+          subject
+        end.to change(User, :count).by(1)
+      end
+
+      it 'リダイレクトされること' do
+        subject
+        expect(response.status).to eq 302
+        expect(response).to redirect_to admin_user_path User.last.id
+      end
+    end
+
+    context 'パラメータが不正な場合' do
+      subject do
+        post admin_users_path, params: { user: FactoryBot.attributes_for(:user, :admin, name: nil) }
+      end
+
+      it 'ユーザーが登録されないこと' do
+        expect do
+          subject
+        end.to_not change(User, :count)
+      end
+
+      it 'エラーが表示されること' do
+        subject
+        expect(response.body).to include 'ユーザーの作成に失敗しました'
+      end
+    end
+  end
+
+  describe '#update' do
+    context 'パラメータが妥当な場合' do
+      subject do
+        put admin_user_path admin,
+                            params: { user: FactoryBot.attributes_for(:user, :admin, name: 'admin2',
+                                                                                     email: 'admin2@admin.com', is_admin: false) }
+      end
+
+      it 'ユーザー名が更新されること' do
+        expect do
+          subject
+        end.to change { User.find(admin.id).name }.from('admin').to('admin2')
+      end
+
+      it 'メールアドレスが更新されること' do
+        expect do
+          subject
+        end.to change { User.find(admin.id).email }.from('admin@admin.com').to('admin2@admin.com')
+      end
+
+      it 'メールアドレスが更新されること' do
+        expect do
+          subject
+        end.to change { User.find(admin.id).is_admin }.from(true).to(false)
+      end
+
+      it 'リダイレクトされること' do
+        subject
+        expect(response.status).to eq 302
+        expect(response).to redirect_to admin_users_path User.last.id
+      end
+    end
+
+    context 'パラメータが不正な場合' do
+      subject do
+        put admin_user_path admin,
+                            params: { user: FactoryBot.attributes_for(:user, :admin, name: nil, email: nil,
+                                                                                     is_admin: nil) }
+      end
+
+      it 'ユーザー名が変更されないこと' do
+        expect do
+          subject
+        end.to_not change(User.find(admin.id), :name)
+      end
+
+      it 'メールアドレスが変更されないこと' do
+        expect do
+          subject
+        end.to_not change(User.find(admin.id), :email)
+      end
+
+      it '管理者権限が変更されないこと' do
+        expect do
+          subject
+        end.to_not change(User.find(admin.id), :is_admin)
+      end
+
+      it 'エラーが表示されること' do
+        subject
+        expect(response.body).to include 'ユーザーの編集に失敗しました'
+      end
+    end
+  end
+
+  describe '#destroy' do
+    context '管理者が2人以上いる場合' do
+      let!(:admin2) { create(:user, :admin) }
+      subject { delete admin_user_path admin }
+
+      it 'ユーザーが削除されること' do
+        expect do
+          subject
+        end.to change(User, :count).by(-1)
+      end
+
+      it 'リダイレクトされること' do
+        subject
+        expect(response).to redirect_to admin_users_path
+      end
+    end
+
+    context '管理者が1人しかいない場合' do
+      subject { delete admin_user_path admin }
+
+      it 'ユーザーが削除されないこと' do
+        expect do
+          subject
+        end.to_not change(User, :count)
+      end
+
+      it 'エラーが表示されること' do
+        subject
+        expect(response.body).to include '管理者は最低1人必要です'
+      end
+    end
+  end
 end


### PR DESCRIPTION
## やったこと
・is_adminカラムを追加しtrueなら管理者、falseなら一般ユーザーのようなロール分け

・以下のようなメソッドを作成しadmin/users_controllerのbefore_actionで実行し管理ユーザだけがユーザ管理画面にアクセスできるように
```
def admin_user
    redirect_to(root_path) unless current_user.is_admin?
 end
```

・ロールを選択はadmin/users/edit.html.erbにてフォームのセレクトタグを使用し実装

・ユーザーの削除制限はmodels/user.rbにて以下のメソッドをbefore_destroyで実行し実装
```
def leave_at_least_one_admin_user
    unless User.where(is_admin: true).count > 1
      errors.add(:is_admin, "管理者は最低1人必要です")
      throw(:abort)
    end
  end
```

## やらないこと
一般ユーザが管理画面にアクセスした場合、専用の例外を出してみましょう
→ステップ26にて実装

## できるようになること（ユーザ目線）
管理者権限を持ったユーザーのみ管理者ページに飛べる

## できなくなること（ユーザ目線）
管理者以外管理者ページに飛べない
